### PR TITLE
Updated for Trident lab 5.0

### DIFF
--- a/LabAnsibleDockerPlugin/2_Lab_NAS_iSCSI/3-rhel-connect-lun/tasks/main.yml
+++ b/LabAnsibleDockerPlugin/2_Lab_NAS_iSCSI/3-rhel-connect-lun/tasks/main.yml
@@ -7,7 +7,7 @@
     portal: "{{ item.iscsi_portal }}"
   with_items: "{{ iSCSI_Storage }}"
 
-- name: Create a filesystem on /dev/sdb
+- name: Create a filesystem on /dev/sdc
   filesystem:
     fstype: "{{ item.filesystem }}"
     dev: "{{ item.volume }}"

--- a/LabAnsibleDockerPlugin/3_Lab_NAS_SnapMirror/3-svm-create/tasks/main.yml
+++ b/LabAnsibleDockerPlugin/3_Lab_NAS_SnapMirror/3-svm-create/tasks/main.yml
@@ -38,6 +38,7 @@
     home_port: "{{ item.LIF_home_port }}" 
     home_node: "{{ item.LIF_home_node }}" 
     role: intercluster
+    ipspace: "{{ item.ipspace }}"
     address: "{{ item.LIF_IP }}"
     netmask: "{{ LIF_netmask }}"
     vserver: "{{ item.svm }}" 

--- a/LabAnsibleDockerPlugin/3_Lab_NAS_SnapMirror/3-svm-create/vars/main.yml
+++ b/LabAnsibleDockerPlugin/3_Lab_NAS_SnapMirror/3-svm-create/vars/main.yml
@@ -13,9 +13,9 @@ Create_DATA_LIFS:
 #-----> Create INTERCLUSTER Logical Interfaces (LIFs) 
 Create_INTERCLUSTER_LIFS:
     - { LIF_Name: INTERCLUSTER_SRC, LIF_IP: 192.168.0.200, svm: cluster1, LIF_home_node: cluster1-01, 
-        LIF_netmask: 255.255.255.0, LIF_home_port: e0c }
+        LIF_netmask: 255.255.255.0, LIF_home_port: e0c, ipspace: "Default" }
     - { LIF_Name: INTERCLUSTER_DST, LIF_IP: 192.168.0.210, svm: cluster1, LIF_home_node: cluster1-01, 
-        LIF_netmask: 255.255.255.0, LIF_home_port: e0d }
+        LIF_netmask: 255.255.255.0, LIF_home_port: e0d, ipspace: "Default" }
 
 #-----> Create Routes
 Create_Routes:

--- a/LabAnsibleKubernetesWithTrident/0-Trident-config/backend-ansible.json
+++ b/LabAnsibleKubernetesWithTrident/0-Trident-config/backend-ansible.json
@@ -4,6 +4,7 @@
     "backendName": "Backend-For-Ansible",
     "managementLIF": "192.168.0.135",
     "storagePrefix": "ansible_",
+    "svm": "nfs_svm",
     "username": "vsadmin",
     "password": "Netapp1!"
 }

--- a/LabAnsibleKubernetesWithTrident/2_Lab_NAS_iSCSI/3-rhel-connect-lun/tasks/main.yml
+++ b/LabAnsibleKubernetesWithTrident/2_Lab_NAS_iSCSI/3-rhel-connect-lun/tasks/main.yml
@@ -7,7 +7,7 @@
     portal: "{{ item.iscsi_portal }}"
   with_items: "{{ iSCSI_Storage }}"
 
-- name: Create a filesystem on /dev/sdb
+- name: Create a filesystem on /dev/sdc
   filesystem:
     fstype: "{{ item.filesystem }}"
     dev: "{{ item.volume }}"

--- a/LabAnsibleKubernetesWithTrident/2_Lab_NAS_iSCSI/3-rhel-connect-lun/vars/main.yml
+++ b/LabAnsibleKubernetesWithTrident/2_Lab_NAS_iSCSI/3-rhel-connect-lun/vars/main.yml
@@ -1,4 +1,4 @@
 #-----> Mount iSCSI LUN to host
 # --- for this demo, we are not building a partition in the volume
 iSCSI_Storage:
-    - { local_volume: DEMO_ANSIBLE_iSCSI, volume: /dev/sdb, filesystem: ext4, iscsi_portal: 192.168.0.150 }
+    - { local_volume: DEMO_ANSIBLE_iSCSI, volume: /dev/sdc, filesystem: ext4, iscsi_portal: 192.168.0.150 }

--- a/LabAnsibleKubernetesWithTrident/3_Lab_NAS_SnapMirror/3-svm-create/tasks/main.yml
+++ b/LabAnsibleKubernetesWithTrident/3_Lab_NAS_SnapMirror/3-svm-create/tasks/main.yml
@@ -39,6 +39,7 @@
     home_node: "{{ item.LIF_home_node }}" 
     role: intercluster
     address: "{{ item.LIF_IP }}"
+    ipspace: "{{ item.ipspace }}"
     netmask: "{{ LIF_netmask }}"
     vserver: "{{ item.svm }}" 
     hostname: "{{ netapp_hostname }}"

--- a/LabAnsibleKubernetesWithTrident/3_Lab_NAS_SnapMirror/3-svm-create/vars/main.yml
+++ b/LabAnsibleKubernetesWithTrident/3_Lab_NAS_SnapMirror/3-svm-create/vars/main.yml
@@ -13,9 +13,9 @@ Create_DATA_LIFS:
 #-----> Create INTERCLUSTER Logical Interfaces (LIFs) 
 Create_INTERCLUSTER_LIFS:
     - { LIF_Name: INTERCLUSTER_SRC, LIF_IP: 192.168.0.200, svm: cluster1, LIF_home_node: cluster1-01, 
-        LIF_netmask: 255.255.255.0, LIF_home_port: e0c }
+        LIF_netmask: 255.255.255.0, LIF_home_port: e0c, ipspace: "Default" }
     - { LIF_Name: INTERCLUSTER_DST, LIF_IP: 192.168.0.210, svm: cluster1, LIF_home_node: cluster1-01, 
-        LIF_netmask: 255.255.255.0, LIF_home_port: e0d }
+        LIF_netmask: 255.255.255.0, LIF_home_port: e0d, ipspace: "Default" }
 
 #-----> Create Routes
 Create_Routes:

--- a/LabAnsibleKubernetesWithTrident/3_Lab_NAS_SnapMirror/4-svm-cleanup/tasks/main.yml
+++ b/LabAnsibleKubernetesWithTrident/3_Lab_NAS_SnapMirror/4-svm-cleanup/tasks/main.yml
@@ -42,6 +42,7 @@
   netapp.ontap.na_ontap_interface:
     state: absent 
     interface_name: "{{ item.LIF_Name }}" 
+    role: intercluster
     vserver: "{{ item.svm }}" 
     hostname: "{{ netapp_hostname }}"
     username: "{{ netapp_username }}"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This lab is entended to test NetApp Ansible modules.
 The variables used in this repo correspond to following NetApp Lab on Demand:
 
-- "Using Trident with Kubernetes and ONTAP v4.0"
+- "Using Trident with Kubernetes and ONTAP v5.0"
 
 The playbooks you are about to run use the NetApp Collection available on Ansible Galaxy.
 This lab has been tested & validated with the schmots1/ansible image v15 (March 2020).


### PR DESCRIPTION
- Added svm name in trident backend, without it pvc binding fails
- Added ipspace as a required parameter for cluster-scoped lif (intercluster)
- Added "role" in the intercluster lif cleanup task, otherwise lifs are not found and regarded as "absent"
- Change /dev/sdb to /dev/sdc for iSCSI lun as sdb is already in use on rhel hosts for /var/lib/docker